### PR TITLE
solved changing set to prepend in config/webpack/environment.js

### DIFF
--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -2,7 +2,7 @@ const { environment } = require('@rails/webpacker')
 
 // Bootstrap 3 has a dependency over jQuery:
 const webpack = require('webpack')
-environment.plugins.set('Provide',
+environment.plugins.prepend('Provide',
   new webpack.ProvidePlugin({
     $: 'jquery',
     jQuery: 'jquery'


### PR DESCRIPTION
New rails project using Le Wagon devise template
Error: Webpacker::Manifest::MissingEntryError
I then run: brew install yarn + yarn install + ./bin/webpack
But the last one gave me another error: ‘TypeError: environment.plugins.set is not a function’, for which I changed set to prepend in config/webpack/environment.js .
Apparently coming from the webpacker version (3.3.1) available in the template.